### PR TITLE
Update bundled JRE to 17.0.9+9

### DIFF
--- a/jre-version.json
+++ b/jre-version.json
@@ -1,12 +1,12 @@
 {
   "mac": {
     "x64": {
-      "semver": "17.0.8+101",
-      "openjdk_version": "17.0.8.1+1"
+      "semver": "17.0.9+9",
+      "openjdk_version": "17.0.9+9"
     },
     "aarch64": {
-      "semver": "17.0.8+101",
-      "openjdk_version": "17.0.8.1+1"
+      "semver": "17.0.9+9",
+      "openjdk_version": "17.0.9+9"
     }
   },
   "windows": {
@@ -17,8 +17,8 @@
   },
   "linux": {
     "x64": {
-      "semver": "17.0.8+101",
-      "openjdk_version": "17.0.8.1+1"
+      "semver": "17.0.9+9",
+      "openjdk_version": "17.0.9+9"
     }
   }
 }


### PR DESCRIPTION
This automated pull request updates the bundled JRE versions to the new security patch release 17.0.9+9.