### PR TITLE
Update bundled JRE to 17.0.9+9.1

### DIFF
--- a/jre-version.json
+++ b/jre-version.json
@@ -11,8 +11,8 @@
   },
   "windows": {
     "x64": {
-      "semver": "17.0.8+101",
-      "openjdk_version": "17.0.8.1+1"
+      "semver": "17.0.9+9.1",
+      "openjdk_version": "17.0.9+9"
     }
   },
   "linux": {

--- a/scripts/jre-update/get-jre.mjs
+++ b/scripts/jre-update/get-jre.mjs
@@ -256,7 +256,7 @@ for (const platform of platforms) {
 
     const arches = platform === "darwin" ? ["x64", "aarch64"] : ["x64"]
     for (const arch of arches) {
-        const version = jreVersions[os]?.[arch]?.openjdk_version
+        const version = jreVersions[os]?.[arch]?.semver
 
         if (!version) {
             throw new Error(`Could not find JRE version for ${os} (${arch}) in versions file (${jreVersionFile}).`)


### PR DESCRIPTION
This automated pull request updates the bundled JRE versions to the new security patch release 17.0.9+9.1.